### PR TITLE
[test.yml] Remove 2.8 tests and add coveralls

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "ckan-2.10"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "ckan-2.10"
+    open-pull-requests-limit: 10

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "ckan-2.10"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "ckan-2.10"
+    open-pull-requests-limit: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,4 +64,4 @@ jobs:
       if: startsWith(runner.os, 'Linux')
       run: curl -sL https://coveralls.io/coveralls-linux.tar.gz | tar -xz && ./coveralls
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,5 +60,8 @@ jobs:
       run: pytest --ckan-ini=test.ini --cov=ckanext.scheming ckanext/scheming/tests
     - name: Run plugin subclassing tests
       run: pytest --ckan-ini=test_subclass.ini ckanext/scheming/tests/test_dataset_display.py ckanext/scheming/tests/test_form.py::TestDatasetFormNew ckanext/scheming/tests/test_dataset_logic.py
-    - name: Report Coveralls
-      uses: coverallsapp/github-action@v2
+    - name: Report Coveralls (Linux)
+      if: startsWith(runner.os, 'Linux')
+      run: curl -sL https://coveralls.io/coveralls-linux.tar.gz | tar -xz && ./coveralls
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: ["2.10", 2.9, 2.9-py2, 2.8]
+        ckan-version: ["2.10", 2.9]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}
@@ -56,12 +56,9 @@ jobs:
       run: |
         pip install -r test-requirements.txt
         ckan -c test.ini db init
-    - name: Setup extension (CKAN < 2.9)
-      if: ${{ matrix.ckan-version == '2.8' }}
-      run: |
-        pip install -r test-requirements-py2.txt
-        paster --plugin=ckan db init -c test.ini
     - name: Run all tests
       run: pytest --ckan-ini=test.ini --cov=ckanext.scheming ckanext/scheming/tests
     - name: Run plugin subclassing tests
       run: pytest --ckan-ini=test_subclass.ini ckanext/scheming/tests/test_dataset_display.py ckanext/scheming/tests/test_form.py::TestDatasetFormNew ckanext/scheming/tests/test_dataset_logic.py
+    - name: Report Coveralls
+      uses: coverallsapp/github-action@v2

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This CKAN extension provides a way to configure and share metadata schemas using
 YAML or JSON schema description. Custom validation and template snippets for editing
 and display are supported.
 
-[![Tests](https://github.com/ckan/ckanext-scheming/workflows/Tests/badge.svg?branch=master)](https://github.com/ckan/ckanext-scheming/actions)
+[![Tests](https://github.com/datopian/ckanext-scheming/workflows/Tests/badge.svg?branch=master)](https://github.com/datopian/ckanext-scheming/actions)
+[![Coverage Status](https://coveralls.io/repos/github/datopian/ckanext-s3filestore/badge.svg?branch=master)](https://coveralls.io/github/datopian/ckanext-s3filestore?branch=master)
 
 Table of contents:
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This CKAN extension provides a way to configure and share metadata schemas using
 YAML or JSON schema description. Custom validation and template snippets for editing
 and display are supported.
 
-[![Tests](https://github.com/datopian/ckanext-scheming/workflows/Tests/badge.svg?branch=master)](https://github.com/datopian/ckanext-scheming/actions)
-[![Coverage Status](https://coveralls.io/repos/github/datopian/ckanext-s3filestore/badge.svg?branch=master)](https://coveralls.io/github/datopian/ckanext-s3filestore?branch=master)
+[![Tests](https://github.com/datopian/ckanext-scheming/workflows/Tests/badge.svg?branch=ckan-2.10)](https://github.com/datopian/ckanext-scheming/actions)
+[![Coverage Status](https://coveralls.io/repos/github/datopian/ckanext-scheming/badge.svg?branch=master)](https://coveralls.io/github/datopian/ckanext-scheming?branch=ckan-2.10)
 
 Table of contents:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ YAML or JSON schema description. Custom validation and template snippets for edi
 and display are supported.
 
 [![Tests](https://github.com/datopian/ckanext-scheming/workflows/Tests/badge.svg?branch=ckan-2.10)](https://github.com/datopian/ckanext-scheming/actions)
-[![Coverage Status](https://coveralls.io/repos/github/datopian/ckanext-scheming/badge.svg?branch=master)](https://coveralls.io/github/datopian/ckanext-scheming?branch=ckan-2.10)
+[![Coverage Status](https://coveralls.io/repos/github/datopian/ckanext-scheming/badge.svg?branch=coverage/ckan-2.10)](https://coveralls.io/github/datopian/ckanext-scheming?branch=coverage/ckan-2.10)
 
 Table of contents:
 


### PR DESCRIPTION
This PR

- Removes CKAN 2.9 py2 and 2.8 tests and adds coveralls coverage report along with badges fixed in the README.md
- Adds dependabot cofig file